### PR TITLE
Fix css selector for img

### DIFF
--- a/slider.css
+++ b/slider.css
@@ -1,4 +1,4 @@
-.slider ul li img {
+.slider ul li > img {
 	display: block;
 	max-width: 100%;
 	object-fit: cover;


### PR DESCRIPTION
This fixes nested img's inside of the carousel by using a direct child selector.

### Example

```
<Carousel switcher={true} indicator={true}>
  <div>
    <strong>Hello World</strong>
    // The img below I don't want any styles applied to
    <img src="/public/img/some_image.png" />
  </div>
  <div>
    <strong>Hello World 2</strong>
    // The img below I don't want any styles applied to
    <img src="/public/img/some_image_2.png" />
  </div>
</Carousel>
```

If this was by design, apologize, but it was causing me some issues!