### PR TITLE
Update peerDependencies. Support React 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "index.js"
   ],
   "peerDependencies": {
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react": "^15.5.4 || ^16.0.0",
+    "react-dom": "^15.5.4 || ^16.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
Since React 16 is released for a while.
I think we can support React 16 for now.